### PR TITLE
Adding external emote dictionary and mod actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,14 @@ COPY requirements.txt .
 # Install the Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the configuration file to the container
-COPY config.yaml .
+# ARG statement to declare the build argument
+ARG CONFIG=config
 
 # Copy the Python script to the container
 COPY bot.py .
+
+# Copy the configuration file to the container
+COPY ${CONFIG}.yaml ./config.yaml
 
 # Set the entry point for the container
 CMD ["python", "bot.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+TAGS := $(patsubst %.yaml,%,$(wildcard *.yaml))
+TAGS := $(filter-out docker-compose,$(TAGS))
+
+.PHONY: all $(TAGS)
+
+all: $(TAGS)
+
+$(TAGS):
+	    @echo ""
+	    @echo ""
+	    @echo "building config for: ${@}.yaml"
+	    @echo ""
+	    @echo ""
+	    @export TAG=$@ && podman-compose up -d --build --force-recreate
+
+config:
+	
+	    @export TAG= && podman-compose up -d --build --force-recreate
+
+	    
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 replicates twitch chat into a discord chat through webhooks
 
 for the twitch bit you can go to https://chatterino.com/client_login, copy your credentials, and set them up on the config file
+
+
+you can just execute `python bot.py` to execute, but you can go the Docker/Podman route.
+
+
+If you decide to go the podman route, install podman and podman-compose, and if you decide to use docker and docker-compose just replace `podman-compose` to `docker-compose` in `Makefile`.
+
+
+If you want to launch only one instance just create a `config.yaml` and just execute `make`, This will create an image called `twitch2discord-bridge:default` and a container called `t2d_bot`.
+
+If you want to launch multiple intances of the bot (each for a different webhook for example) create one or more config files with any name you choose like `<name>.yaml` (Ex.: `henya.yaml`) and execute `make`. This will create images with the name you choose (Ex.: `twitch2discord-bot:henya`) and also a container (Ex.: `t2d_henya`), and if you have multiple config files it will do the same for each.
+
+If you want to build just for one of them just do `make <name>` (Ex.: `make henya`) and only that image/container will be updated.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+
+services:
+  twitch2discord-bridge:
+    logging:
+      options:
+        max-size: 500m
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+      args:
+        - CONFIG=${TAG:-config}
+
+    restart: always
+    image: twitch2discord-bridge:${TAG:-default}
+    container_name: t2d_${TAG:-bot}
+    

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,4 +1,3 @@
-
 webhook_url: 'DISCORD WEBHOOK URL'
 twitch_client_id: 'YOUR TWITCH ID'
 twitch_username: 'YOUR TWITCH USERNAME'
@@ -6,34 +5,53 @@ oauth_password: 'YOUR TWITCH OAUTH PASSWORD (NOT YOUR REAL PASSWORD)'
 channel: 'THE CHANNEL NAME'
 
 # any configuration bellow is not mandatory, you can delete any of the tags if you're not gonna use it 
+# HOWEVER, it's important to note that the bot is incredibly slow when running without filters 
 
 # filters the message with Bits
-show_bit_gifters: true
+#show_bit_gifters: true
+
+# shold create a log.txt file 
+#log_file: false
+
+# records sent messages and display them whenever someone gets timed out / banned
+#mod_actions: true
 
 # filtering by badges only work if the badge is visible.
 # you can check the log.txt to see what badges are being used by users
-filter_badges: 
-  - broadcaster
-  - vip
-  - moderator
+# Ex.: you have a filter for `verified`, but then a verified gifted 1000 bits. 
+# Now that verified has a `1000 gifter` badge in place of the `verified` one and won't show anymore.
+#filter_badges: 
+#  - broadcaster
+#  - vip
+#  - moderator
 
 # this uses the username, not the display name.
 # in the log.txt it will be like this: 
 # USERNAME (DISPLAY_NAME)
-filter_usernames: 
-  - soundalerts
+#filter_usernames: 
+#  - soundalerts
 
 # this uses regex. Go nuts 
-filter_messages:
-  - 'Cheer\d+.*' # this detects any cheer people sends
+#filter_messages:
+#  - '[^\x20-\x7F]' # this regex detects any message that uses non roman characters, like Chinese, Japanese, etc.
 
 # this translates twitch emotes to an equivalent you might have on your server, or any server.
 # you can create a server for just dumping twitch emotes if you don't want them to clog your original one.
 # no nitro needed
+# this only translates twitch emotes by looking at what emotes people can use
 #
 # To get these codes you can use \ before the emote ( \:HenyaDance: )
-emote_translator:
-  'henyatDance': '<a:HenyaDance:1107237388587114567>'
-  'henyatKettle': '<:henyaKettle:1108918704747577425>'
-  'henyatHenyaheart': '<:HenyaHeart:1107237396036190270>'
-  'henyatZoom': '<:henyaZoom:1107237413656481884>'
+
+#emote_translator:
+#  'henyatDance': '<a:HenyaDance:1107237388587114567>'
+#  'henyatKettle': '<:henyaKettle:1108918704747577425>'
+#  'henyatHenyaheart': '<:HenyaHeart:1107237396036190270>'
+#  'henyatZoom': '<:henyaZoom:1107237413656481884>'
+
+# or you can create a separate file with the same content and host it on the web.
+# You can upload your file into a github repo, get the raw link, and use it here
+# that the bot will try to update it every 10 seconds.
+# Just beware that when using github the raw file is kept in cache for 3 minutes.
+# so you'll only see a change in around 3 minutes after updating it on github.
+#emote_translator_url: 'https://raw.githubusercontent.com/kabessao/twitch2discordBridge-HenyaEmotes/main/emotes.yaml'
+


### PR DESCRIPTION
This version adds the following:

* ability to host the emotes dictionary in the web by using the `emote_translator_web`;
* ability to see when someone gets timed out/banned and their last messages;
* ability to use podman/discord;
* ability to have multiple instances of the bot using podman/docker compose;
* ability to disable the log.txt file creation, since using podman/docker accomplishes the same. 